### PR TITLE
chore: upgrade ci to run against Neovim 0.8.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.8.2
+          version: v0.8.3
 
       - name: generate documentation
         run: make documentation-ci
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 2
     strategy:
       matrix:
-        neovim_version: ['v0.7.2', 'v0.8.2', 'nightly']
+        neovim_version: ['v0.7.2', 'v0.8.3', 'nightly']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## 📃 Summary

update the CI to run against Neovim 0.8.3
